### PR TITLE
Set PlaybackService's notification priority to HIGH

### DIFF
--- a/app/src/main/java/org/interview/jorge/playback/server/PlaybackService.kt
+++ b/app/src/main/java/org/interview/jorge/playback/server/PlaybackService.kt
@@ -110,7 +110,7 @@ internal class PlaybackService
         NotificationChannel(
           getString(R.string.playback_service_notification_channel_id),
           getString(R.string.playback_service_notification_channel_name),
-          NotificationManager.IMPORTANCE_DEFAULT
+          NotificationManager.IMPORTANCE_HIGH
         )
       )
   }


### PR DESCRIPTION
This increases the odds of it appearing expanded,
which is crucial as otherwise only the play/pause
button/indicator will show initially.