### PR TITLE
Test timed metadata on Apple's test HLS stream

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,7 @@ android {
     versionName String.valueOf(versionCode)
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     testInstrumentationRunnerArguments clearPackageData: "true"
+    multiDexEnabled true
   }
   variantFilter {
     it.ignore = !it.buildType.isDebuggable()

--- a/app/src/main/java/org/interview/jorge/playback/datasource/applehlstest/AppleHlsTestStream.kt
+++ b/app/src/main/java/org/interview/jorge/playback/datasource/applehlstest/AppleHlsTestStream.kt
@@ -1,0 +1,12 @@
+package org.interview.jorge.playback.datasource.applehlstest
+
+import org.interview.jorge.playback.datasource.Stream
+
+/**
+ * @see <a href=https://developer.apple.com/streaming/examples/>Apple HLS examples</a>
+ */
+internal enum class AppleHlsTestStream(id: CharSequence) : Stream {
+  BIPBOP_16x9("bipbop_16x9");
+
+  val playlistUrl = "https://devstreaming-cdn.apple.com/videos/streaming/examples/$id/${id}_variant.m3u8"
+}

--- a/app/src/main/java/org/interview/jorge/playback/datasource/applehlstest/HardcodedAppleHlsTestStreamMediaItemRetriever.kt
+++ b/app/src/main/java/org/interview/jorge/playback/datasource/applehlstest/HardcodedAppleHlsTestStreamMediaItemRetriever.kt
@@ -1,0 +1,26 @@
+package org.interview.jorge.playback.datasource.applehlstest
+
+import android.net.Uri
+import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.MediaMetadata
+import org.interview.jorge.playback.datasource.MediaItemRetriever
+import java.util.concurrent.ExecutorService
+
+internal class HardcodedAppleHlsTestStreamMediaItemRetriever(executorService: ExecutorService) :
+  MediaItemRetriever<AppleHlsTestStream>(executorService) {
+
+  override fun createRetrievalRunnable(source: AppleHlsTestStream) = Runnable {
+    try {
+      mediaItemRequestCallback?.onMediaItemRetrieved(
+        source,
+        MediaItem.Builder()
+          .setTag(source.name)
+          .setUri(Uri.parse(source.playlistUrl))
+          .setMediaMetadata(MediaMetadata.Builder().setTitle(source.name).build())
+          .build()
+      )
+    } catch (throwable: Throwable) {
+      mediaItemRequestCallback?.onMediaItemRetrievalError(source, throwable)
+    }
+  }
+}

--- a/app/src/main/java/org/interview/jorge/playback/server/PlaybackService.kt
+++ b/app/src/main/java/org/interview/jorge/playback/server/PlaybackService.kt
@@ -19,6 +19,8 @@ import org.interview.jorge.playback.datasource.applehlstest.AppleHlsTestStream
 import org.interview.jorge.playback.datasource.applehlstest.HardcodedAppleHlsTestStreamMediaItemRetriever
 import java.util.concurrent.Future
 import javax.inject.Inject
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
 
 internal class PlaybackService
   : Service(), MediaItemRetriever.MediaItemRequestCallback<AppleHlsTestStream>, Player.Listener {
@@ -110,3 +112,16 @@ internal class PlaybackService
 }
 
 internal const val PLAYBACK_SERVICE_FOREGROUND_NOTIFICATION_ID = 1
+
+private fun Any.toStringByReflection(): String {
+  val propsString = this::class.memberProperties
+    .joinToString(", ") {
+      val wasAccessible = it.isAccessible
+      it.isAccessible = true
+      val value = it.getter.call(this).toString()
+      it.isAccessible = wasAccessible
+      "${it.name}=${value}"
+    };
+
+  return "${this::class.simpleName} [${propsString}]"
+}

--- a/app/src/main/java/org/interview/jorge/playback/server/PlaybackService.kt
+++ b/app/src/main/java/org/interview/jorge/playback/server/PlaybackService.kt
@@ -10,6 +10,7 @@ import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.PlaybackException
 import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.metadata.Metadata
 import com.google.android.exoplayer2.source.MediaSourceFactory
 import com.google.android.exoplayer2.ui.PlayerNotificationManager
 import com.google.android.exoplayer2.upstream.cache.Cache
@@ -107,6 +108,12 @@ internal class PlaybackService
       } else {
         stopSelf()
       }
+    }
+  }
+
+  override fun onMetadata(metadata: Metadata) {
+    for (i in 0 until metadata.length()) {
+      Log.d(javaClass.name, "onMetadata (i=$i): ${metadata.get(i).toStringByReflection()}")
     }
   }
 }

--- a/app/src/main/java/org/interview/jorge/playback/server/PlaybackServiceModule.kt
+++ b/app/src/main/java/org/interview/jorge/playback/server/PlaybackServiceModule.kt
@@ -7,6 +7,7 @@ import android.os.Handler
 import android.os.Looper
 import androidx.core.app.NotificationCompat
 import com.google.android.exoplayer2.C.WAKE_MODE_NETWORK
+import com.google.android.exoplayer2.DefaultRenderersFactory
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.RenderersFactory
 import com.google.android.exoplayer2.SimpleExoPlayer
@@ -55,8 +56,7 @@ internal abstract class PlaybackServiceModule {
     @Provides
     @Reusable
     @Local
-    fun renderersFactory(@Local context: Context): RenderersFactory =
-      MediaCodecAudioRenderersFactory(context)
+    fun renderersFactory(@Local context: Context): RenderersFactory = DefaultRenderersFactory(context)
 
     @Provides
     @Reusable

--- a/app/src/main/java/org/interview/jorge/playback/server/PlaybackServiceModule.kt
+++ b/app/src/main/java/org/interview/jorge/playback/server/PlaybackServiceModule.kt
@@ -29,13 +29,11 @@ import com.google.android.exoplayer2.upstream.cache.NoOpCacheEvictor
 import com.google.android.exoplayer2.upstream.cache.SimpleCache
 import com.google.android.exoplayer2.util.NotificationUtil
 import dagger.Binds
-import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
 import org.interview.jorge.R
-import org.interview.jorge.playback.datasource.tidalinterview.ActualTestStreamMediaItemRetriever
-import org.interview.jorge.playback.datasource.tidalinterview.HardcodedTestStreamMediaItemRetriever
+import org.interview.jorge.playback.datasource.applehlstest.HardcodedAppleHlsTestStreamMediaItemRetriever
 import java.io.File
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -92,23 +90,15 @@ internal abstract class PlaybackServiceModule {
 
     @Provides
     @PlaybackServiceComponent.Scoped
-    fun hardcodedTestStreamMediaItemRetriever(@Local singleThreadExecutorService: ExecutorService) =
-      HardcodedTestStreamMediaItemRetriever(singleThreadExecutorService)
-
-    @Provides
-    @PlaybackServiceComponent.Scoped
-    @Local
-    fun customActionReceiver(
-      hardcodedTestStreamMediaItemRetrieverLazy: Lazy<HardcodedTestStreamMediaItemRetriever>
-    ): PlayerNotificationManager.CustomActionReceiver =
-      PlaybackServiceCustomActionReceiver(hardcodedTestStreamMediaItemRetrieverLazy)
+    fun hardcodedAppleHlsTestStreamMediaItemRetriever(
+      @Local singleThreadExecutorService: ExecutorService
+    ) = HardcodedAppleHlsTestStreamMediaItemRetriever(singleThreadExecutorService)
 
     @Provides
     @PlaybackServiceComponent.Scoped
     fun playerNotificationManager(
       @Local context: Context,
       @Local notificationListener: PlayerNotificationManager.NotificationListener,
-      @Local customActionReceiver: PlayerNotificationManager.CustomActionReceiver
     ) = PlayerNotificationManager.Builder(
       context,
       PLAYBACK_SERVICE_FOREGROUND_NOTIFICATION_ID,
@@ -116,7 +106,6 @@ internal abstract class PlaybackServiceModule {
     ).setNotificationListener(notificationListener)
       .setChannelNameResourceId(R.string.playback_service_notification_channel_name)
       .setChannelImportance(NotificationUtil.IMPORTANCE_HIGH)
-      .setCustomActionReceiver(customActionReceiver)
       .build().apply {
         setUsePreviousAction(true)
         setUseNextAction(true)
@@ -129,11 +118,6 @@ internal abstract class PlaybackServiceModule {
     @Reusable
     @Local
     fun singleThreadExecutorService(): ExecutorService = Executors.newSingleThreadExecutor()
-
-    @Provides
-    @PlaybackServiceComponent.Scoped
-    fun actualTestStreamMediaItemRetriever(@Local singleThreadExecutorService: ExecutorService) =
-      ActualTestStreamMediaItemRetriever(singleThreadExecutorService)
 
     @Provides
     @Reusable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ gradlePluginAndroid = { module = "com.android.tools.build:gradle", version.ref =
 gradlePluginKotlinAndroid = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 junit = { module = "junit:junit", version.ref = "junit"}
 kotlinStdLib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 androidxInstrumentedTestRunner = { module = "androidx.test:runner", version.ref = "androidxTest" }
 androidxInstrumentedTestRules = { module = "androidx.test:rules", version.ref = "androidxTest" }
 androidxTestExtJunit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExt" }
@@ -32,7 +33,7 @@ mockitoAndroid = { module = "org.mockito:mockito-android", version.ref = "mockit
 gradlePluginsAndroid = ["gradlePluginAndroid"]
 gradlePluginsKotlin = ["gradlePluginKotlinAndroid"]
 junit = ["junit"]
-kotlin = ["kotlinStdLib"]
+kotlin = ["kotlinStdLib", "kotlinReflect"]
 androidxTest = ["androidxInstrumentedTestRunner", "androidxInstrumentedTestRules", "androidxTestExtJunit"]
 androidxTestOrchestrator = ["androidxTestOrchestrator"]
 dagger = ["dagger"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ androidxTestExt = { strictly = "1.1.3" }
 dagger = { strictly = "2.38.1" }
 androidxMedia = { strictly = "1.4.1" }
 mockitoKotlin = { strictly = "3.2.0" }
-exoPlayer = { strictly = "2.15.0" }
+exoPlayer = { strictly = "2.18.0" }
 mockito = { strictly = "3.12.4" }
 
 [libraries]


### PR DESCRIPTION
Stream from https://developer.apple.com/streaming/examples/ (the one that has timed metadata)

The metadata is received without a problem

<img width="1702" alt="Screenshot 2022-07-12 at 14 21 08" src="https://user-images.githubusercontent.com/1732935/178488368-ff1e7038-ded7-4e23-8e67-07c5729978d6.png">
